### PR TITLE
Remove separate developer game client from flow and instead use Haste Arcade by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,19 +19,6 @@
         "node": "16.X"
       }
     },
-    "node_modules/@auth0/auth0-spa-js": {
-      "version": "1.18.0",
-      "license": "MIT",
-      "dependencies": {
-        "abortcontroller-polyfill": "^1.7.3",
-        "browser-tabs-lock": "^1.2.14",
-        "core-js": "^3.16.3",
-        "es-cookie": "^1.3.2",
-        "fast-text-encoding": "^1.0.3",
-        "promise-polyfill": "^8.2.0",
-        "unfetch": "^4.2.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.16.0",
       "dev": true,
@@ -4211,10 +4198,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/abortcontroller-polyfill": {
-      "version": "1.7.3",
-      "license": "MIT"
-    },
     "node_modules/accepts": {
       "version": "1.3.7",
       "license": "MIT",
@@ -5206,14 +5189,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/browser-tabs-lock": {
-      "version": "1.2.15",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": ">=4.17.21"
-      }
     },
     "node_modules/browserslist": {
       "version": "4.19.1",
@@ -6268,15 +6243,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/core-js": {
-      "version": "3.17.3",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-js-compat": {
@@ -7454,10 +7420,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-cookie": {
-      "version": "1.3.2",
-      "license": "MIT"
-    },
     "node_modules/es-module-lexer": {
       "version": "0.9.3",
       "dev": true,
@@ -8633,10 +8595,6 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-text-encoding": {
-      "version": "1.0.3",
-      "license": "Apache-2.0"
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
@@ -13301,6 +13259,7 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -19261,10 +19220,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/promise-polyfill": {
-      "version": "8.2.0",
-      "license": "MIT"
-    },
     "node_modules/promise.series": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/promise.series/-/promise.series-0.2.0.tgz",
@@ -23172,10 +23127,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/unfetch": {
-      "version": "4.2.0",
-      "license": "MIT"
-    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -25138,10 +25089,9 @@
     },
     "packages/web": {
       "name": "@hastearcade/web",
-      "version": "2.0.6",
+      "version": "2.0.7-next.3",
       "license": "MIT",
       "dependencies": {
-        "@auth0/auth0-spa-js": "^1.18.0",
         "@hastearcade/models": "^1.3.0",
         "@types/axios": "^0.14.0",
         "@types/uuid": "^8.3.3",
@@ -25180,18 +25130,6 @@
     }
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": {
-      "version": "1.18.0",
-      "requires": {
-        "abortcontroller-polyfill": "^1.7.3",
-        "browser-tabs-lock": "^1.2.14",
-        "core-js": "^3.16.3",
-        "es-cookie": "^1.3.2",
-        "fast-text-encoding": "^1.0.3",
-        "promise-polyfill": "^8.2.0",
-        "unfetch": "^4.2.0"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.16.0",
       "dev": true,
@@ -26772,7 +26710,6 @@
     "@hastearcade/web": {
       "version": "file:packages/web",
       "requires": {
-        "@auth0/auth0-spa-js": "^1.18.0",
         "@hastearcade/models": "^1.3.0",
         "@semantic-release/git": "^9.0.0",
         "@types/axios": "^0.14.0",
@@ -28275,9 +28212,6 @@
       "version": "1.1.1",
       "dev": true
     },
-    "abortcontroller-polyfill": {
-      "version": "1.7.3"
-    },
     "accepts": {
       "version": "1.3.7",
       "requires": {
@@ -28959,12 +28893,6 @@
     "browser-process-hrtime": {
       "version": "1.0.0",
       "dev": true
-    },
-    "browser-tabs-lock": {
-      "version": "1.2.15",
-      "requires": {
-        "lodash": ">=4.17.21"
-      }
     },
     "browserslist": {
       "version": "4.19.1",
@@ -29682,9 +29610,6 @@
     "copy-descriptor": {
       "version": "0.1.1",
       "dev": true
-    },
-    "core-js": {
-      "version": "3.17.3"
     },
     "core-js-compat": {
       "version": "3.20.0",
@@ -30456,9 +30381,6 @@
         "unbox-primitive": "^1.0.1"
       }
     },
-    "es-cookie": {
-      "version": "1.3.2"
-    },
     "es-module-lexer": {
       "version": "0.9.3",
       "dev": true
@@ -31226,9 +31148,6 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "dev": true
-    },
-    "fast-text-encoding": {
-      "version": "1.0.3"
     },
     "fastest-levenshtein": {
       "version": "1.0.12",
@@ -34269,7 +34188,8 @@
       }
     },
     "lodash": {
-      "version": "4.17.21"
+      "version": "4.17.21",
+      "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -38351,9 +38271,6 @@
       "version": "2.0.3",
       "dev": true
     },
-    "promise-polyfill": {
-      "version": "8.2.0"
-    },
     "promise.series": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/promise.series/-/promise.series-0.2.0.tgz",
@@ -41014,9 +40931,6 @@
           "dev": true
         }
       }
-    },
-    "unfetch": {
-      "version": "4.2.0"
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/packages/haste-game-client/src/game/hasteGame.ts
+++ b/packages/haste-game-client/src/game/hasteGame.ts
@@ -18,9 +18,9 @@ export class HasteGame extends Phaser.Game {
   // and server, a JWT from the haste game is leveraged. This JWT will
   // contain the necessary information necessary to validate the client
   // to the server, and contain the player id from the user metadata
-  async setupSocket(hasteClient: HasteClient) {
+  setupSocket(hasteClient: HasteClient) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const details = await hasteClient.getTokenDetails();
+    const details = hasteClient.getTokenDetails();
     const serverUrl = `${process.env.SERVER_PROTOCOL}://${process.env.SERVER_HOST}:${process.env.SERVER_PORT}`;
     this.socketManager = new SocketManager(serverUrl, details.token);
 

--- a/packages/haste-game-client/src/scenes/bootScene.ts
+++ b/packages/haste-game-client/src/scenes/bootScene.ts
@@ -31,7 +31,7 @@ export class BootScene extends Phaser.Scene {
   }
 
   init(): void {
-    this.hasteClient = HasteClient.build(process.env.AUTH_URL, process.env.LOGIN_URL, process.env.HASTE_GAME_CLIENT_ID);
+    this.hasteClient = HasteClient.build(process.env.LOGIN_URL);
     const details = this.hasteClient.getTokenDetails();
     this.handleLoggedInUser(details);
   }

--- a/packages/haste-game-client/src/scenes/bootScene.ts
+++ b/packages/haste-game-client/src/scenes/bootScene.ts
@@ -30,17 +30,17 @@ export class BootScene extends Phaser.Scene {
     this.hasteClient.login();
   }
 
-  async init(): Promise<void> {
-    this.hasteClient = HasteClient.build(process.env.HASTE_GAME_CLIENT_ID, process.env.AUTH_URL, process.env.LOGIN_URL);
-    const details = await this.hasteClient.getTokenDetails();
-    await this.handleLoggedInUser(details);
+  init(): void {
+    this.hasteClient = HasteClient.build(process.env.AUTH_URL, process.env.LOGIN_URL, process.env.HASTE_GAME_CLIENT_ID);
+    const details = this.hasteClient.getTokenDetails();
+    this.handleLoggedInUser(details);
   }
 
-  async handleLoggedInUser(hasteAuth: HasteAuthentication) {
+  handleLoggedInUser(hasteAuth: HasteAuthentication) {
     this.isAuthenticated = hasteAuth.isAuthenticated;
     if (hasteAuth.isAuthenticated) {
       const hasteGame = this.game as HasteGame;
-      await hasteGame.setupSocket(this.hasteClient);
+      hasteGame.setupSocket(this.hasteClient);
 
       hasteGame.socketManager.gameGetLevelsCompletedEvent.on((data: Leaderboard[]) => {
         hasteGame.leaderboards = data;

--- a/packages/haste-game-client/webpack.development.js
+++ b/packages/haste-game-client/webpack.development.js
@@ -33,6 +33,7 @@ if (fs.existsSync(path)) {
         });
       },
       host: '0.0.0.0',
+      disableHostCheck: true,
     },
     plugins: [new DefinePlugin(envKeys)],
   });

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,7 +43,6 @@
     "payout"
   ],
   "dependencies": {
-    "@auth0/auth0-spa-js": "^1.18.0",
     "@hastearcade/models": "^1.3.0",
     "@types/axios": "^0.14.0",
     "@types/uuid": "^8.3.3",

--- a/packages/web/src/api/hasteClient.ts
+++ b/packages/web/src/api/hasteClient.ts
@@ -59,7 +59,7 @@ export class HasteClient {
   public logout() {
     localStorage.removeItem('haste:config');
     localStorage.removeItem('token');
-    window.location.href = window.location.origin;
+    window.location.href = `https://authclient.foundrium.hastearcade.com/logout?redirect_uri=${window.location.origin}`;
   }
 
   public getTokenDetails() {

--- a/packages/web/src/api/hasteClient.ts
+++ b/packages/web/src/api/hasteClient.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { isBrowser } from '../util/environmentCheck';
-import { Auth0Client } from '@auth0/auth0-spa-js';
 import { HasteClientConfiguration } from '../config/hasteClientConfiguration';
 import jwtDecode, { JwtPayload } from 'jwt-decode';
 import { v4 } from 'uuid';
@@ -13,17 +12,15 @@ export type HasteAuthentication = {
 };
 
 export class HasteClient {
-  private auth0Client: Auth0Client;
   private configuration: HasteClientConfiguration;
 
-  private constructor(configuration: HasteClientConfiguration, auth0Client: Auth0Client) {
+  private constructor(configuration: HasteClientConfiguration) {
     this.configuration = configuration;
-    this.auth0Client = auth0Client;
   }
 
   public static build(
     domain = 'auth.hastearcade.com',
-    signinUrl = 'https://authclient.hastearcade.com/signin',
+    signinUrl = 'https://authclient.hastearcade.com',
     clientId = 'EUN4fvO6AJIjVImZxhPAw9ofpw9LrB7g',
   ) {
     if (!isBrowser())
@@ -31,35 +28,22 @@ export class HasteClient {
         `Haste client build can only be called from a browser based environment. If you are on running @hastearcade/web on a server, please use the server package.`,
       );
 
-    const auth0 = new Auth0Client({
-      audience: 'https://haste.api',
+    return new HasteClient({
       domain: domain,
-      client_id: clientId,
-      scope: 'offline_access',
-      useRefreshTokens: true,
-      useCookiesForTransactions: true,
-      cacheLocation: 'localstorage',
+      clientId: clientId,
+      signinUrl: `${signinUrl}`,
     });
-
-    return new HasteClient(
-      {
-        domain: domain,
-        clientId: clientId,
-        signinUrl: signinUrl,
-      },
-      auth0,
-    );
   }
 
   public login() {
     const hint = btoa(`${v4()};;;;;${window.location.href};;;;;${'gamelogin'}`);
-    window.location.href = `https://authclient.foundrium.hastearcade.com/landing?login_hint=${hint}`;
+    window.location.href = `${this.configuration.signinUrl}/landing?login_hint=${hint}`;
   }
 
   public logout() {
     localStorage.removeItem('haste:config');
     localStorage.removeItem('token');
-    window.location.href = `https://authclient.foundrium.hastearcade.com/logout?redirect_uri=${window.location.origin}`;
+    window.location.href = `${this.configuration.signinUrl}/logout?redirect_uri=${window.location.origin}`;
   }
 
   public getTokenDetails() {

--- a/packages/web/src/api/hasteClient.ts
+++ b/packages/web/src/api/hasteClient.ts
@@ -18,19 +18,13 @@ export class HasteClient {
     this.configuration = configuration;
   }
 
-  public static build(
-    domain = 'auth.hastearcade.com',
-    signinUrl = 'https://authclient.hastearcade.com',
-    clientId = 'EUN4fvO6AJIjVImZxhPAw9ofpw9LrB7g',
-  ) {
+  public static build(signinUrl = 'https://authclient.hastearcade.com') {
     if (!isBrowser())
       throw new Error(
         `Haste client build can only be called from a browser based environment. If you are on running @hastearcade/web on a server, please use the server package.`,
       );
 
     return new HasteClient({
-      domain: domain,
-      clientId: clientId,
       signinUrl: `${signinUrl}`,
     });
   }

--- a/packages/web/src/config/hasteClientConfiguration.ts
+++ b/packages/web/src/config/hasteClientConfiguration.ts
@@ -1,11 +1,7 @@
 export class HasteClientConfiguration {
-  domain: string;
-  clientId: string;
   signinUrl: string;
 
-  constructor(clientId: string, domain = 'auth.hastearcade.com', signinUrl: 'https://app.hastearcade.com/signin') {
-    this.clientId = clientId;
-    this.domain = domain;
+  constructor(signinUrl: 'https://authclient.hastearcade.com') {
     this.signinUrl = signinUrl;
   }
 }


### PR DESCRIPTION
# Description

Some upgrades to our auth system to support a few new features and also remove the dependency upon Auth0 applications as we hit the 100 applications limit and didn't want to pay $2500 a month.

# Linked Issues

Link to any Jira issues that this pull request closes.

- [ ] HM-499 - ensure games login you in when you hit "Play Game" from the arcade
- [ ] HM-495 - Refactor away from Auth0 applications
- [ ] HM-496 - refactor the haste-web-sdk to use the Auth0 Haste Arcade application instead of a separate developer's
